### PR TITLE
Correspond to other type of amazon affilicate link.

### DIFF
--- a/src/js/convert_amazon_link.js
+++ b/src/js/convert_amazon_link.js
@@ -19,6 +19,9 @@ $(function() {
 				}else{
 					replace = url + "?" + affiliate_key;
 				}
+				if (replace.match(/\/[a-z]+-22/)) {
+					replace = replace.replace(/\/[a-z]+-22/, "/" + affiliate_key);
+				}
 				$(this).attr('href', replace);
 			}
 		});


### PR DESCRIPTION
# Features
Correspond to other type of amazon affilicate link.

ex.
```
http://www.amazon.co.jp/exec/obidos/ASIN/B00K00W9LI/ymizushi-22/
```